### PR TITLE
Use $wpdb->last_error and surface not-found context

### DIFF
--- a/lib/Traits/CanQueryWordPressDatabase.php
+++ b/lib/Traits/CanQueryWordPressDatabase.php
@@ -31,7 +31,8 @@ trait CanQueryWordPressDatabase
         }
 
         if (is_null($result)) {
-            throw new DatastoreErrorException($wpdb->error);
+            $message = $wpdb->last_error ?: ($wpdb->error ?? 'Get results failed.');
+            throw new DatastoreErrorException($message);
         }
 
         if (empty($result)) {

--- a/lib/Traits/CanQueryWordPressDatabase.php
+++ b/lib/Traits/CanQueryWordPressDatabase.php
@@ -25,18 +25,18 @@ trait CanQueryWordPressDatabase
     {
         global $wpdb;
         try {
-            $result = $wpdb->get_results($queryBuilder->build(), ARRAY_A);
+            $query = $queryBuilder->build();
+            $result = $wpdb->get_results($query, ARRAY_A);
         } catch (QueryBuilderException $e) {
             throw new DatastoreErrorException('Get results failed. Invalid query: ' . $e->getMessage(), 500, $e);
         }
 
         if (is_null($result)) {
-            $message = $wpdb->last_error ?: ($wpdb->error ?? 'Get results failed.');
-            throw new DatastoreErrorException($message);
+            throw new DatastoreErrorException('Get results failed - ' . $wpdb->last_error);
         }
 
         if (empty($result)) {
-            throw new RecordNotFoundException();
+            throw new RecordNotFoundException('No records found for query: ' . $query);
         }
 
         return $result;
@@ -53,7 +53,8 @@ trait CanQueryWordPressDatabase
         global $wpdb;
 
         try {
-            $result = $wpdb->get_row($queryBuilder->build(), ARRAY_A);
+            $query = $queryBuilder->build();
+            $result = $wpdb->get_row($query, ARRAY_A);
         } catch (QueryBuilderException $e) {
             throw new DatastoreErrorException('Get row failed. Invalid query', 500, $e);
         }
@@ -63,7 +64,7 @@ trait CanQueryWordPressDatabase
                 throw new DatastoreErrorException('Get row failed - ' . $wpdb->last_error);
             }
 
-            throw new RecordNotFoundException('Could not get the specified row because it does not exist.');
+            throw new RecordNotFoundException('No record found for query: ' . $query);
         }
 
         return $result;
@@ -150,7 +151,12 @@ trait CanQueryWordPressDatabase
                 ->where($clauseBuilder);
 
             if (0 === (int)$this->wpdbGetVar($queryBuilder)) {
-                throw new RecordNotFoundException('The update failed because no record exists.');
+                throw new RecordNotFoundException(sprintf(
+                    'Update failed because no record exists in table "%s" for identity %s. Requested changes: %s.',
+                    $table->getName(),
+                    $this->encodeExceptionContext($where),
+                    $this->encodeExceptionContext($data)
+                ));
             }
         }
     }
@@ -183,19 +189,33 @@ trait CanQueryWordPressDatabase
     {
         global $wpdb;
         try {
-            $result = $wpdb->get_var($queryBuilder->build());
+            $query = $queryBuilder->build();
+            $result = $wpdb->get_var($query);
         } catch (QueryBuilderException $e) {
             throw new DatastoreErrorException('Get var failed - Invalid query', 500, $e);
         }
 
         if (is_null($result)) {
             if (empty($wpdb->last_error)) {
-                throw new RecordNotFoundException();
+                throw new RecordNotFoundException('No value found for query: ' . $query);
             } else {
                 throw new DatastoreErrorException('Get var failed - ' . $wpdb->last_error);
             }
         }
 
         return $result;
+    }
+
+    /**
+     * Formats exception context so datastore errors carry the table identity and payloads
+     * that triggered the failing operation.
+     *
+     * @param array<string, mixed> $context
+     */
+    protected function encodeExceptionContext(array $context): string
+    {
+        $encoded = json_encode($context, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return $encoded === false ? '[unserializable context]' : $encoded;
     }
 }

--- a/tests/Unit/Traits/CanQueryWordPressDatabaseTest.php
+++ b/tests/Unit/Traits/CanQueryWordPressDatabaseTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace PHPNomad\Integrations\WordPress\Tests\Unit\Traits;
+
+use PHPNomad\Database\Interfaces\QueryBuilder;
+use PHPNomad\Datastore\Exceptions\DatastoreErrorException;
+use PHPNomad\Integrations\WordPress\Tests\TestCase;
+use PHPNomad\Integrations\WordPress\Traits\CanQueryWordPressDatabase;
+
+class CanQueryWordPressDatabaseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!defined('ARRAY_A')) {
+            define('ARRAY_A', 'ARRAY_A');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['wpdb']);
+        parent::tearDown();
+    }
+
+    public function testWpdbGetResultsUsesLastErrorWhenQueryReturnsNull(): void
+    {
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->expects($this->once())
+            ->method('build')
+            ->willReturn('SELECT * FROM test_table');
+
+        $GLOBALS['wpdb'] = new class {
+            public string $last_error = 'Replica read failed';
+            public string $error = '';
+
+            public function get_results(string $query, string $output): ?array
+            {
+                return null;
+            }
+        };
+
+        $subject = new class {
+            use CanQueryWordPressDatabase;
+
+            public function getResults(QueryBuilder $queryBuilder): array
+            {
+                return $this->wpdbGetResults($queryBuilder);
+            }
+        };
+
+        $this->expectException(DatastoreErrorException::class);
+        $this->expectExceptionMessage('Replica read failed');
+
+        $subject->getResults($queryBuilder);
+    }
+}

--- a/tests/Unit/Traits/CanQueryWordPressDatabaseTest.php
+++ b/tests/Unit/Traits/CanQueryWordPressDatabaseTest.php
@@ -2,8 +2,11 @@
 
 namespace PHPNomad\Integrations\WordPress\Tests\Unit\Traits;
 
+use PHPNomad\Database\Factories\Column;
 use PHPNomad\Database\Interfaces\QueryBuilder;
+use PHPNomad\Database\Interfaces\Table;
 use PHPNomad\Datastore\Exceptions\DatastoreErrorException;
+use PHPNomad\Datastore\Exceptions\RecordNotFoundException;
 use PHPNomad\Integrations\WordPress\Tests\TestCase;
 use PHPNomad\Integrations\WordPress\Traits\CanQueryWordPressDatabase;
 
@@ -33,7 +36,6 @@ class CanQueryWordPressDatabaseTest extends TestCase
 
         $GLOBALS['wpdb'] = new class {
             public string $last_error = 'Replica read failed';
-            public string $error = '';
 
             public function get_results(string $query, string $output): ?array
             {
@@ -51,8 +53,54 @@ class CanQueryWordPressDatabaseTest extends TestCase
         };
 
         $this->expectException(DatastoreErrorException::class);
-        $this->expectExceptionMessage('Replica read failed');
+        $this->expectExceptionMessage('Get results failed - Replica read failed');
 
         $subject->getResults($queryBuilder);
+    }
+
+    public function testWpdbUpdateIncludesTableIdentityAndPayloadWhenRecordIsMissing(): void
+    {
+        $table = $this->createMock(Table::class);
+        $table->method('getName')->willReturn('wp_test_records');
+        $table->method('getAlias')->willReturn('records');
+        $table->method('getFieldsForIdentity')->willReturn(['id']);
+        $table->method('getColumns')->willReturn([
+            new Column('id', 'INT'),
+        ]);
+
+        $GLOBALS['wpdb'] = new class {
+            public string $last_error = '';
+
+            public function update(string $table, array $data, array $where, array $formats, array $whereFormats): int
+            {
+                return 0;
+            }
+
+            public function get_var(string $query): string
+            {
+                return '0';
+            }
+
+            public function prepare(string $query, mixed ...$args): string
+            {
+                return $query;
+            }
+        };
+
+        $subject = new class {
+            use CanQueryWordPressDatabase;
+
+            public function updateRecord(Table $table, array $data, array $where): void
+            {
+                $this->wpdbUpdate($table, $data, $where);
+            }
+        };
+
+        $this->expectException(RecordNotFoundException::class);
+        $this->expectExceptionMessage('Update failed because no record exists in table "wp_test_records"');
+        $this->expectExceptionMessage('"id":123');
+        $this->expectExceptionMessage('"status":"complete"');
+
+        $subject->updateRecord($table, ['status' => 'complete'], ['id' => 123]);
     }
 }


### PR DESCRIPTION
## Summary
- use `wpdb->last_error` directly when `get_results()` returns `null`
- enrich missing-record exceptions with the actual query or table identity/update payload context
- add coverage for the null-result and missing-record update paths

## Why
The Siren 2.3.3 obligation investigation exposed two problems in the WordPress query layer: it was reading the wrong wpdb error property, and its record-not-found exceptions did not carry enough context to debug what identity or query had actually failed.

## Testing
- `vendor/bin/phpunit tests/Unit/Traits/CanQueryWordPressDatabaseTest.php`