### PR TITLE
[codex] Use plain IN for single WordPress identity fields

### DIFF
--- a/lib/Database/ClauseBuilder.php
+++ b/lib/Database/ClauseBuilder.php
@@ -94,14 +94,18 @@ class ClauseBuilder implements ClauseBuilderInterface
         }
 
         if (is_array($field)) {
-            $fieldStr = Arr::process($field)
-                ->filter(fn($field) => $this->tableHasField($field))
-                ->map(fn($field) => $this->prependField($field))
-                ->setSeparator(', ')
-                ->toString();
+            $fields = [];
 
-            if (!empty($fieldStr)) {
-                $result = "($fieldStr)";
+            foreach ($field as $fieldName) {
+                if ($this->tableHasField($fieldName)) {
+                    $fields[] = $this->prependField($fieldName);
+                }
+            }
+
+            if (count($fields) === 1) {
+                $result = Arr::first($fields);
+            } elseif (!empty($fields)) {
+                $result = '(' . implode(', ', $fields) . ')';
             }
         }
 
@@ -229,11 +233,17 @@ class ClauseBuilder implements ClauseBuilderInterface
         if ($operator === 'IN' || $operator === 'NOT IN') {
 
             // Group fields with multiple $field values (%s,%s),(%s,%s), else just flatten them %s,%s,%s,%s
-            if (is_array($field)) {
+            if (is_array($field) && count($field) > 1) {
                 $subgroup = "(" . implode(', ', array_fill(0, count($field), '%s')) . ")";
                 $placeholderGroup = implode(', ', array_fill(0, count($values), $subgroup));
             } else {
-                $placeholderGroup = implode(', ', array_fill(0, count($values), '%s'));
+                $placeholderCount = 0;
+
+                foreach ($values as $value) {
+                    $placeholderCount += is_array($value) ? count($value) : 1;
+                }
+
+                $placeholderGroup = implode(', ', array_fill(0, $placeholderCount, '%s'));
             }
 
             return "($placeholderGroup)";

--- a/tests/Unit/Database/ClauseBuilderTest.php
+++ b/tests/Unit/Database/ClauseBuilderTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace PHPNomad\Integrations\WordPress\Tests\Unit\Database;
+
+use PHPNomad\Database\Factories\Column;
+use PHPNomad\Database\Interfaces\Table;
+use PHPNomad\Integrations\WordPress\Database\ClauseBuilder;
+use PHPNomad\Integrations\WordPress\Tests\TestCase;
+
+class ClauseBuilderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['wpdb'] = new FakeWpdb();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['wpdb']);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @covers \PHPNomad\Integrations\WordPress\Database\ClauseBuilder::build
+     */
+    public function testSingleFieldInClauseUsesPlainColumnLookup(): void
+    {
+        $table = new FakeTable();
+        $builder = (new ClauseBuilder())->useTable($table);
+
+        $result = $builder->andWhere(['id'], 'IN', ['id' => 44])->build();
+
+        $this->assertSame("rec.id IN ('44')", $result);
+    }
+
+    /**
+     * @covers \PHPNomad\Integrations\WordPress\Database\ClauseBuilder::build
+     */
+    public function testSingleFieldInClauseExpandsMultipleIdentityRows(): void
+    {
+        $table = new FakeTable();
+        $builder = (new ClauseBuilder())->useTable($table);
+
+        $result = $builder
+            ->andWhere(['id'], 'IN', ['id' => 44], ['id' => 45])
+            ->build();
+
+        $this->assertSame("rec.id IN ('44', '45')", $result);
+    }
+
+    /**
+     * @covers \PHPNomad\Integrations\WordPress\Database\ClauseBuilder::build
+     */
+    public function testCompoundFieldInClauseKeepsRowConstructorLookup(): void
+    {
+        $table = new FakeTable();
+        $builder = (new ClauseBuilder())->useTable($table);
+
+        $result = $builder
+            ->andWhere(['id', 'orgId'], 'IN', ['id' => 44, 'orgId' => 2], ['id' => 45, 'orgId' => 3])
+            ->build();
+
+        $this->assertSame("(rec.id, rec.orgId) IN (('44', '2'), ('45', '3'))", $result);
+    }
+}
+
+class FakeWpdb
+{
+    /**
+     * Prepares a SQL string for assertions.
+     *
+     * @param string $query The query with placeholders.
+     * @param mixed ...$values The values to quote.
+     * @return string
+     */
+    public function prepare(string $query, ...$values): string
+    {
+        foreach ($values as $value) {
+            $query = preg_replace('/%s/', "'" . addslashes((string)$value) . "'", $query, 1);
+        }
+
+        return $query;
+    }
+}
+
+class FakeTable implements Table
+{
+    /** @inheritDoc */
+    public function getName(): string
+    {
+        return 'wp_records';
+    }
+
+    /** @inheritDoc */
+    public function getAlias(): string
+    {
+        return 'rec';
+    }
+
+    /** @inheritDoc */
+    public function getTableVersion(): string
+    {
+        return '1';
+    }
+
+    /** @inheritDoc */
+    public function getColumns(): array
+    {
+        return [
+            new Column('id', 'BIGINT'),
+            new Column('orgId', 'BIGINT'),
+        ];
+    }
+
+    /** @inheritDoc */
+    public function getIndices(): array
+    {
+        return [];
+    }
+
+    /** @inheritDoc */
+    public function getCharset(): ?string
+    {
+        return null;
+    }
+
+    /** @inheritDoc */
+    public function getCollation(): ?string
+    {
+        return null;
+    }
+
+    /** @inheritDoc */
+    public function getFieldsForIdentity(): array
+    {
+        return ['id'];
+    }
+
+    /** @inheritDoc */
+    public function getUnprefixedName(): string
+    {
+        return 'records';
+    }
+
+    /** @inheritDoc */
+    public function getSingularUnprefixedName(): string
+    {
+        return 'record';
+    }
+}


### PR DESCRIPTION
## Summary
- Generate plain single-column `IN` clauses for single identity-field lookups in the WordPress clause builder.
- Preserve row-constructor `IN` SQL for true compound identity fields.
- Add unit coverage for single identity, multiple single-field identities, and compound identities.

## Why
WordPress fetches records such as posts with a direct primary-key predicate (`WHERE ID = %d LIMIT 1`). PHPNomad's WordPress integration was generating row-constructor SQL even for a single identity field, e.g. `(alias.id) IN ((%s))`. This keeps the PHPNomad API unchanged while making the WordPress integration emit the simpler primary-key lookup shape WordPress itself uses for single-column identities.

## Validation
- `vendor/bin/phpunit --filter ClauseBuilderTest --testdox`
- `vendor/bin/phpunit --testdox`
