### PR TITLE
[codex] Use writer-consistent reads after WordPress writes

### DIFF
--- a/lib/Strategies/QueryStrategy.php
+++ b/lib/Strategies/QueryStrategy.php
@@ -12,28 +12,47 @@ class QueryStrategy implements CoreQueryStrategy
 {
     use CanQueryWordPressDatabase;
 
+    /**
+     * Tracks whether this strategy has written during the current request.
+     *
+     * After a write, managed hosts with read replicas may route normal reads to a
+     * stale replica. This flag lets only post-write reads use the writer-consistent
+     * path, so normal reads stay cheap while read-after-write hydration can see
+     * the row that was just inserted or changed.
+     */
+    protected bool $hasWritten = false;
+
     /** @inheritDoc */
     public function query(QueryBuilder $builder): array
     {
+        if ($this->hasWritten) {
+            return $this->wpdbGetResultsAfterWrite($builder);
+        }
+
         return $this->wpdbGetResults($builder);
     }
 
     /** @inheritDoc */
     public function insert(Table $table, array $data): array
     {
-        return $this->wpdbInsert($table, $data);
+        $ids = $this->wpdbInsert($table, $data);
+        $this->hasWritten = true;
+
+        return $ids;
     }
 
     /** @inheritDoc */
     public function delete(Table $table, array $ids): void
     {
         $this->wpdbDelete($table, $ids);
+        $this->hasWritten = true;
     }
 
     /** @inheritDoc */
     public function update(Table $table, array $where, array $data): void
     {
         $this->wpdbUpdate($table, $data, $where);
+        $this->hasWritten = true;
     }
 
     /** @inheritDoc */

--- a/lib/Traits/CanQueryWordPressDatabase.php
+++ b/lib/Traits/CanQueryWordPressDatabase.php
@@ -10,6 +10,7 @@ use PHPNomad\Datastore\Exceptions\DatastoreErrorException;
 use PHPNomad\Integrations\WordPress\Database\ClauseBuilder;
 use PHPNomad\Integrations\WordPress\Database\QueryBuilder as WordPressQueryBuilder;
 use PHPNomad\Utils\Helpers\Arr;
+use Throwable;
 
 trait CanQueryWordPressDatabase
 {
@@ -40,6 +41,43 @@ trait CanQueryWordPressDatabase
         }
 
         return $result;
+    }
+
+    /**
+     * Gets a batch of rows using a writer-consistent read path after a write.
+     *
+     * @param QueryBuilder $queryBuilder
+     * @return array<string, mixed>[]|array<int>
+     * @throws DatastoreErrorException
+     * @throws RecordNotFoundException
+     */
+    protected function wpdbGetResultsAfterWrite(QueryBuilder $queryBuilder): array
+    {
+        global $wpdb;
+
+        if (method_exists($wpdb, 'send_reads_to_masters')) {
+            $wpdb->send_reads_to_masters();
+
+            return $this->wpdbGetResults($queryBuilder);
+        }
+
+        if (false === $wpdb->query('START TRANSACTION')) {
+            throw new DatastoreErrorException('Consistent read failed - could not start transaction: ' . $wpdb->last_error);
+        }
+
+        try {
+            $result = $this->wpdbGetResults($queryBuilder);
+
+            if (false === $wpdb->query('COMMIT')) {
+                throw new DatastoreErrorException('Consistent read failed - could not commit transaction: ' . $wpdb->last_error);
+            }
+
+            return $result;
+        } catch (Throwable $e) {
+            $wpdb->query('ROLLBACK');
+
+            throw $e;
+        }
     }
 
     /**
@@ -81,32 +119,46 @@ trait CanQueryWordPressDatabase
     {
         global $wpdb;
 
-        if (empty($data)) {
-            $inserted = $wpdb->query('INSERT INTO ' . $table->getName() . '() VALUES ();');
-        } else {
-            $inserted = $wpdb->insert($table->getName(), $data, $this->getFormats($data));
+        if (false === $wpdb->query('START TRANSACTION')) {
+            throw new DatastoreErrorException('Insert failed - could not start transaction: ' . $wpdb->last_error);
         }
 
-        if (false === $inserted) {
-            throw new DatastoreErrorException('Insert failed - ' . $wpdb->last_error);
-        }
+        try {
+            if (empty($data)) {
+                $inserted = $wpdb->query('INSERT INTO ' . $table->getName() . '() VALUES ();');
+            } else {
+                $inserted = $wpdb->insert($table->getName(), $data, $this->getFormats($data));
+            }
 
-        $fields = $table->getFieldsForIdentity();
-        $ids = Arr::process($fields)
-            ->reduce(function ($acc, $field) use ($data) {
-                if (isset($data[$field])) {
-                    $acc[$field] = $data[$field];
-                }
+            if (false === $inserted) {
+                throw new DatastoreErrorException('Insert failed - ' . $wpdb->last_error);
+            }
 
-                return $acc;
-            }, [])
-            ->toArray();
+            $fields = $table->getFieldsForIdentity();
+            $ids = Arr::process($fields)
+                ->reduce(function ($acc, $field) use ($data) {
+                    if (isset($data[$field])) {
+                        $acc[$field] = $data[$field];
+                    }
 
-        if (count($ids) === count($fields)) {
+                    return $acc;
+                }, [])
+                ->toArray();
+
+            if (count($ids) !== count($fields)) {
+                $ids = ['id' => $wpdb->insert_id];
+            }
+
+            if (false === $wpdb->query('COMMIT')) {
+                throw new DatastoreErrorException('Insert failed - could not commit transaction: ' . $wpdb->last_error);
+            }
+
             return $ids;
-        }
+        } catch (Throwable $e) {
+            $wpdb->query('ROLLBACK');
 
-        return ['id' => $wpdb->insert_id];
+            throw $e;
+        }
     }
 
     /**

--- a/tests/Unit/Strategies/QueryStrategyTest.php
+++ b/tests/Unit/Strategies/QueryStrategyTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace PHPNomad\Integrations\WordPress\Tests\Unit\Strategies;
+
+use PHPNomad\Database\Interfaces\QueryBuilder;
+use PHPNomad\Database\Interfaces\Table;
+use PHPNomad\Integrations\WordPress\Strategies\QueryStrategy;
+use PHPNomad\Integrations\WordPress\Tests\TestCase;
+
+class QueryStrategyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!defined('ARRAY_A')) {
+            define('ARRAY_A', 'ARRAY_A');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['wpdb']);
+        parent::tearDown();
+    }
+
+    public function testQueryUsesTransactionBackedReadAfterInsert(): void
+    {
+        $GLOBALS['wpdb'] = new class {
+            public int $insert_id = 123;
+            public string $last_error = '';
+            public array $queries = [];
+            private bool $inTransaction = false;
+
+            public function query(string $query): bool
+            {
+                $this->queries[] = $query;
+
+                if ($query === 'START TRANSACTION') {
+                    $this->inTransaction = true;
+                }
+
+                if ($query === 'COMMIT' || $query === 'ROLLBACK') {
+                    $this->inTransaction = false;
+                }
+
+                return true;
+            }
+
+            public function insert(string $table, array $data, array $formats): int
+            {
+                return 1;
+            }
+
+            public function get_results(string $query, string $output): array
+            {
+                return $this->inTransaction ? [['id' => 123, 'name' => 'Example']] : [];
+            }
+        };
+
+        $table = $this->createMock(Table::class);
+        $table->method('getName')->willReturn('wp_test_records');
+        $table->method('getFieldsForIdentity')->willReturn(['id']);
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->expects($this->once())
+            ->method('build')
+            ->willReturn('SELECT * FROM wp_test_records WHERE id = 123');
+
+        $strategy = new QueryStrategy();
+        $strategy->insert($table, ['name' => 'Example']);
+
+        $this->assertSame([['id' => 123, 'name' => 'Example']], $strategy->query($queryBuilder));
+        $this->assertSame(['START TRANSACTION', 'COMMIT', 'START TRANSACTION', 'COMMIT'], $GLOBALS['wpdb']->queries);
+    }
+}

--- a/tests/Unit/Traits/CanQueryWordPressDatabaseTest.php
+++ b/tests/Unit/Traits/CanQueryWordPressDatabaseTest.php
@@ -58,6 +58,56 @@ class CanQueryWordPressDatabaseTest extends TestCase
         $subject->getResults($queryBuilder);
     }
 
+    public function testWpdbInsertResolvesInsertIdInsideTransaction(): void
+    {
+        $table = $this->createMock(Table::class);
+        $table->method('getName')->willReturn('wp_test_records');
+        $table->method('getFieldsForIdentity')->willReturn(['id']);
+
+        $GLOBALS['wpdb'] = new class {
+            public int $insert_id = 123;
+            public string $last_error = '';
+            public array $queries = [];
+            public bool $insertedInTransaction = false;
+            private bool $inTransaction = false;
+
+            public function query(string $query): bool
+            {
+                $this->queries[] = $query;
+
+                if ($query === 'START TRANSACTION') {
+                    $this->inTransaction = true;
+                }
+
+                if ($query === 'COMMIT' || $query === 'ROLLBACK') {
+                    $this->inTransaction = false;
+                }
+
+                return true;
+            }
+
+            public function insert(string $table, array $data, array $formats): int
+            {
+                $this->insertedInTransaction = $this->inTransaction;
+
+                return 1;
+            }
+        };
+
+        $subject = new class {
+            use CanQueryWordPressDatabase;
+
+            public function insertRecord(Table $table, array $data): array
+            {
+                return $this->wpdbInsert($table, $data);
+            }
+        };
+
+        $this->assertSame(['id' => 123], $subject->insertRecord($table, ['name' => 'Example']));
+        $this->assertTrue($GLOBALS['wpdb']->insertedInTransaction);
+        $this->assertSame(['START TRANSACTION', 'COMMIT'], $GLOBALS['wpdb']->queries);
+    }
+
     public function testWpdbUpdateIncludesTableIdentityAndPayloadWhenRecordIsMissing(): void
     {
         $table = $this->createMock(Table::class);


### PR DESCRIPTION
## What changed

This keeps the read-after-write consistency fix entirely inside the WordPress integration.

The behavior is dynamic:

- Normal reads still use the normal `$wpdb->get_results()` path.
- `insert()` resolves `$wpdb->insert_id` inside the same explicit transaction as the insert.
- After `insert()`, `update()`, or `delete()`, the strategy marks that a write occurred.
- Subsequent reads through that strategy instance use a writer-consistent read path.
- If HyperDB-style `send_reads_to_masters()` exists, it is used.
- Otherwise the read is wrapped in a short transaction.

No datastore-layer interface was added. No public API changed.

## Why

PHPNomad's datastore create flow inserts a row, receives an identity, and then reads the model back. On managed WordPress hosts with read/write splitting, that immediate read can hit a stale replica even though the insert succeeded.

This fix keeps normal reads cheap while ensuring reads that happen after a write can see the write.

## Production Evidence

Darren's live SmartWorkflowGuru database was pulled into a disposable test install with WP Migrate DB Pro on April 28, 2026.

Observed production state from the failed Stripe/WooCommerce order:

- WooCommerce order `8870` completed at `2026-04-27 16:27:03` UTC with Stripe/Link payment.
- Siren conversions `19` and `20` were created at `2026-04-27 16:26:49` and `2026-04-27 16:26:57` UTC for engagement `81`.
- Both conversions were `pending` with `transactionId = NULL` and `obligationId = NULL`.
- Siren transaction rows `29` and `30` existed with matching timestamps, proving the inserts did commit.
- Transaction `30` also had a transaction detail row, but neither `29` nor `30` had a `wc_order` mapping for order `8870`.
- Earlier live log entries on the same day show `RecordNotFoundException` from `CanQueryWordPressDatabase.php:38` during `IdentifiableDatabaseDatastoreHandler->create()` after inserting opportunities.

That shape is the failure this PR targets: the write succeeds, then PHPNomad's immediate post-write hydration/read path fails to see the row and callers treat creation as failed.

## Cloudways Test Notes

A standard Cloudways test app was also loaded with the live DB. It reported:

- `$wpdb` class: `wpdb`
- `wp-content/db.php`: absent
- `DB_HOST`: local socket (`localhost:/run/mysqld/mysqld.sock`)

On that standard Cloudways app, the issue did not reproduce:

- 100 direct `$wpdb` insert/select cycles outside a transaction: 0 failures.
- 100 direct `$wpdb` insert/select cycles inside a transaction: 0 failures.
- 10 replays of the WooCommerce `woocommerce_order_status_completed` hook for order `8870` outside a transaction: all created complete conversions with transaction mappings.
- 10 replays of the same hook inside a transaction: all created complete conversions with transaction mappings.

This indicates the standard Cloudways test app is not equivalent to the customer's Cloudways Autonomous database topology. It does not remove the production evidence above; it only explains why the generic Cloudways app did not reproduce the managed-read failure.

## Impact

This should prevent a successful insert from being followed by a stale read that makes PHPNomad behave as if the inserted row does not exist.

The extra transaction work only happens on insert identity resolution and on reads after a write has occurred in the same query strategy instance.

## Validation

- `vendor/bin/phpunit --testdox`
- Result: 49 tests, 80 assertions passing