### PR TITLE
Use prepared %i identifier placeholders in table strategies

### DIFF
--- a/lib/Strategies/QueryStrategy.php
+++ b/lib/Strategies/QueryStrategy.php
@@ -40,7 +40,7 @@ class QueryStrategy implements CoreQueryStrategy
     public function estimatedCount(Table $table): int
     {
         global $wpdb;
-        $rows = $wpdb->get_var("SELECT COUNT(*) FROM " . $table->getName());
+        $rows = $wpdb->get_var($wpdb->prepare('SELECT COUNT(*) FROM %i', $table->getName()));
 
         if ($rows !== null) {
             return (int)$rows;

--- a/lib/Strategies/TableCreateStrategy.php
+++ b/lib/Strategies/TableCreateStrategy.php
@@ -39,13 +39,17 @@ class TableCreateStrategy implements CoreTableCreateStrategy
      */
     protected function buildCreateQuery(Table $table): string
     {
+        global $wpdb;
+
         $args = Arr::process([$this->convertColumnsToSqlString($table), $this->convertIndicesToSqlString($table)])
             ->whereNotEmpty()
             ->setSeparator(",\n ")
             ->toString();
 
+        $tableIdentifier = $wpdb->prepare('%i', $table->getName());
+
         return <<<SQL
-            CREATE TABLE IF NOT EXISTS {$table->getName()} (
+            CREATE TABLE IF NOT EXISTS {$tableIdentifier} (
                 $args
             ) CHARACTER SET {$table->getCharset()} COLLATE {$table->getCollation()};
         SQL;

--- a/lib/Strategies/TableDeleteStrategy.php
+++ b/lib/Strategies/TableDeleteStrategy.php
@@ -21,7 +21,7 @@ class TableDeleteStrategy implements CoreTableDeleteStrategy
     public function delete(string $tableName): void
     {
         try {
-            $this->wpdbQuery("DROP TABLE IF EXISTS $tableName");
+            $this->wpdbQuery('DROP TABLE IF EXISTS %i', $tableName);
         } catch (DatastoreErrorException $e) {
             throw new TableDropFailedException($e->getMessage(), $e->getCode(), $e);
         }

--- a/lib/Strategies/TableUpdateStrategy.php
+++ b/lib/Strategies/TableUpdateStrategy.php
@@ -57,11 +57,11 @@ class TableUpdateStrategy implements CoreTableUpdateStrategy
     protected function getCurrentColumns(string $tableName): array
     {
         global $wpdb;
-        $query = "SELECT COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT, EXTRA
+        $query = 'SELECT COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT, EXTRA
               FROM INFORMATION_SCHEMA.COLUMNS
-              WHERE TABLE_NAME = '{$tableName}'";
+              WHERE TABLE_NAME = %s';
 
-        $results = $wpdb->get_results($wpdb->prepare($query), ARRAY_A);
+        $results = $wpdb->get_results($wpdb->prepare($query, $tableName), ARRAY_A);
         $columns = [];
 
         foreach ($results as $row) {
@@ -101,6 +101,8 @@ class TableUpdateStrategy implements CoreTableUpdateStrategy
      */
     protected function buildSyncColumnsQuery(Table $table): ?string
     {
+        global $wpdb;
+
         $currentColumns = $this->getCurrentColumns($table->getName());
         $newColumns = $table->getColumns();
         $queries = [];
@@ -124,7 +126,7 @@ class TableUpdateStrategy implements CoreTableUpdateStrategy
         // Drop columns that no longer exist in the new definition
         foreach ($currentColumns as $currentColumnName => $currentColumnData) {
             if (!in_array($currentColumnName, $newColumnNames)) {
-                $queries[] = "DROP COLUMN `{$currentColumnName}`";
+                $queries[] = 'DROP COLUMN ' . $wpdb->prepare('%i', $currentColumnName);
             }
         }
 
@@ -137,8 +139,10 @@ class TableUpdateStrategy implements CoreTableUpdateStrategy
             return null;
         }
 
+        $tableIdentifier = $wpdb->prepare('%i', $table->getName());
+
         return <<<SQL
-            ALTER TABLE {$table->getName()} 
+            ALTER TABLE {$tableIdentifier} 
             $args 
         SQL;
     }

--- a/lib/Traits/CanQueryWordPressDatabase.php
+++ b/lib/Traits/CanQueryWordPressDatabase.php
@@ -82,7 +82,7 @@ trait CanQueryWordPressDatabase
         global $wpdb;
 
         if (empty($data)) {
-            $inserted = $wpdb->query('INSERT INTO ' . $table->getName() . '() VALUES ();');
+            $inserted = $wpdb->query($wpdb->prepare('INSERT INTO %i() VALUES ();', $table->getName()));
         } else {
             $inserted = $wpdb->insert($table->getName(), $data, $this->getFormats($data));
         }


### PR DESCRIPTION
All table/column identifiers now go through `$wpdb->prepare()` with `%i` (WP 6.2+); INFORMATION_SCHEMA's TABLE_NAME comparison becomes a proper `%s` value placeholder, and the zero-arg `prepare()` misuse (fires `_doing_it_wrong`) is gone. Package suite green (59 tests). Fixes #33.

Surfaced by Siren's WordPress.org review simulation — direct sibling of a real round-4 review finding.