### PR TITLE
fix(rest): skip middleware for method-mismatched permission checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "phpnomad/wordpress-integration",
     "description": "",
-    "version": "4.3.2",
+    "version": "4.3.3",
     "type": "library",
     "homepage": "https://github.com/phpnomad/core",
     "readme": "README.md",

--- a/lib/Strategies/RestStrategy.php
+++ b/lib/Strategies/RestStrategy.php
@@ -98,6 +98,18 @@ class RestStrategy implements CoreRestStrategy
             return true;
         }
 
+        // WordPress invokes EVERY method's permission callback on the
+        // matched route while rest_send_allow_header builds the Allow
+        // header — including methods that are not being dispatched. Running
+        // another verb's middleware against a request shaped for this verb
+        // produces spurious validation failures, null-param warnings, and
+        // pointless queries. Only the dispatching method's callback can
+        // run, so only its middleware outcome matters; advertise the
+        // method and let a real request of that verb run its own chain.
+        if (strtoupper($wpRequest->get_method()) !== strtoupper($controller->getMethod())) {
+            return true;
+        }
+
         $outcomes = $this->middlewareOutcomes[$wpRequest] ?? [];
         $controllerClass = get_class($controller);
 

--- a/tests/Unit/Strategies/RestStrategyPermissionsTest.php
+++ b/tests/Unit/Strategies/RestStrategyPermissionsTest.php
@@ -247,4 +247,28 @@ class RestStrategyPermissionsTest extends TestCase
 
         $this->assertInstanceOf(WP_Error::class, $result);
     }
+
+    public function testMismatchedMethodControllerSkipsMiddlewareEntirely(): void
+    {
+        // rest_send_allow_header checks the POST controller's permission
+        // callback during a GET request; running its middleware against a
+        // GET-shaped request fires validations with null params.
+        $middleware = new class implements Middleware {
+            public int $runs = 0;
+
+            public function process(Request $request): void
+            {
+                $this->runs++;
+            }
+        };
+
+        $controller = $this->makeControllerWithMiddleware($middleware); // getMethod() === 'GET'
+        $strategy = $this->makeStrategy();
+        $wpRequest = new WP_REST_Request('POST');
+
+        $result = $this->checkPermissions($strategy, $controller, $wpRequest);
+
+        $this->assertTrue($result);
+        $this->assertSame(0, $middleware->runs);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -120,6 +120,18 @@ if (!class_exists('WP_Error')) {
 if (!class_exists('WP_REST_Request')) {
     class WP_REST_Request
     {
+        private string $method;
+
+        public function __construct(string $method = 'GET')
+        {
+            $this->method = $method;
+        }
+
+        public function get_method(): string
+        {
+            return $this->method;
+        }
+
         public function get_params(): array
         {
             return [];


### PR DESCRIPTION
Follow-up to #39: the Allow-header pass still ran sibling-method middleware once per controller against a wrong-shaped request, producing null-param warnings and unbound-placeholder DB errors under WP_DEBUG (caught by Siren's fresh-install smoke walk). A controller whose method doesn't match the dispatching request can never run, so its permission check now returns true without executing the chain. New regression test; 68 tests green.